### PR TITLE
Added - Extract Tasks from selection into Omnifocus Command

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -80,7 +80,7 @@ export default class TasksToOmnifocus extends Plugin {
 
 					if (this.settings.markComplete) {
 						let completedText = editorText.replace(/- \[ \]/g, "- [x]");
-						editor.setValue(completedText);
+						editor.replaceSelection(completedText);
 					}
 
 				} catch (err) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,6 +57,37 @@ export default class TasksToOmnifocus extends Plugin {
 				}
 			},
 		});
+		
+		this.addCommand({
+			id: 'extract-tasks-selection',
+			name: 'Extract Tasks from selection Into OmniFocus',
+			editorCallback: (editor: Editor, view: MarkdownView) => {
+				const editorText = editor.getSelection()
+				try {
+					let tasks = editorText.match(/- \[ \] .*/g);
+
+					for (let task of tasks) {
+						let taskName = task.replace("- [ ] ", "");
+						let taskNameEncoded = encodeURIComponent(taskName);
+						let noteURL = view.file.path.replace(/ /g, "%20").replace(/\//g, "%2F");
+						let vaultName = app.vault.getName();
+						let taskNoteEncoded = encodeURIComponent("obsidian://open?=" + vaultName + "&file=" + noteURL);
+
+						window.open(
+							`omnifocus:///add?name=${taskNameEncoded}&note=${taskNoteEncoded}`
+						);
+					}
+
+					if (this.settings.markComplete) {
+						let completedText = editorText.replace(/- \[ \]/g, "- [x]");
+						editor.setValue(completedText);
+					}
+
+				} catch (err) {
+
+				}
+			},
+		});
 
 		this.addSettingTab(new TasksToOmnifocusSettingTab(this.app, this));
 	}


### PR DESCRIPTION
Add's new command "Extract Tasks from selection into OmniFocus"

Replace selection with completed marks if the option is selected.

My first ever pull request, so I have no idea if this is how it's done but I've tested and is working on my local.