### PR TITLE
Fix spaces in vault name

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -55,7 +55,7 @@ export default class TasksToOmnifocus extends Plugin {
 				let taskName = task.replace("- [ ] ", "");
 				let taskNameEncoded = encodeURIComponent(taskName);
 				let noteURL = view.file.path.replace(/ /g, "%20").replace(/\//g, "%2F");
-				let vaultName = app.vault.getName();
+				let vaultName = app.vault.getName().replace(/\s/g, "%20");
 				let taskNoteEncoded = encodeURIComponent("obsidian://open?=" + vaultName + "&file=" + noteURL);
 
 				window.open(

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,7 @@ export default class TasksToOmnifocus extends Plugin {
 		this.addSettingTab(new TasksToOmnifocusSettingTab(this.app, this));
 	}
 
-	async addToOmnifocus(isSelection: bool, editor: Editor, view: MarkdownView) {
+	async addToOmnifocus(isSelection: boolean, editor: Editor, view: MarkdownView) {
 		var editorText;
 		if (isSelection) {
 			editorText = editor.getSelection();


### PR DESCRIPTION
This is a small fix to handle if there is a space in the vault name. It replaces spaces with `%20F`. It also fixes an improper boolean typing.

Fixes #4 